### PR TITLE
hire: make target team a dropdown

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,8 @@
   - Storybook
   - Playwright
 - Invites
+- Add resume upload
+- Add interview notes
 
 ## Later
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## MVP
 
 - Add candidate button
-- Login page
 - Make target team a select field
 - Finalize candidate fields
 - Basic error handling and toast notifications

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## MVP
 
 - Add candidate button
-- Make target team a select field
 - Finalize candidate fields
 - Basic error handling and toast notifications
 

--- a/apps/hire/convex/_generated/api.d.ts
+++ b/apps/hire/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as model_companies from "../model/companies.js";
 import type * as roles from "../roles.js";
 import type * as seniorities from "../seniorities.js";
 import type * as sources from "../sources.js";
+import type * as targetTeams from "../targetTeams.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -41,6 +42,7 @@ declare const fullApi: ApiFromModules<{
   roles: typeof roles;
   seniorities: typeof seniorities;
   sources: typeof sources;
+  targetTeams: typeof targetTeams;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/apps/hire/convex/boards.ts
+++ b/apps/hire/convex/boards.ts
@@ -65,6 +65,10 @@ export const getBoardWithData = boardQuery({
         .withIndex("by_company_order", (q) => q.eq("companyId", companyId))
         .collect(),
       candidates,
+      targetTeams: await ctx.db
+        .query("targetTeams")
+        .withIndex("by_company_order", (q) => q.eq("companyId", companyId))
+        .collect(),
     };
   },
   returns: BoardWithDataSchema.nullable(),

--- a/apps/hire/convex/schema.ts
+++ b/apps/hire/convex/schema.ts
@@ -24,7 +24,7 @@ export default defineSchema({
     salaryExpectations: v.optional(v.string()),
     seniorityId: v.optional(v.id("seniorities")),
     sourceId: v.optional(v.id("sources")),
-    targetTeam: v.optional(v.string()),
+    targetTeamId: v.optional(v.id("targetTeams")),
     updatedAt: v.number(), // store as timestamp (Date.now())
   }).index("by_company", ["companyId"]),
   companies: defineTable({
@@ -47,6 +47,11 @@ export default defineSchema({
     order: v.float64(),
   }).index("by_company_order", ["companyId", "order"]),
   sources: defineTable({
+    companyId: v.id("companies"),
+    name: v.string(),
+    order: v.float64(),
+  }).index("by_company_order", ["companyId", "order"]),
+  targetTeams: defineTable({
     companyId: v.id("companies"),
     name: v.string(),
     order: v.float64(),

--- a/apps/hire/convex/seniorities.ts
+++ b/apps/hire/convex/seniorities.ts
@@ -48,7 +48,10 @@ export const addSeniority = seniorityMutation({
 });
 
 export const reorderSeniorities = seniorityMutation({
-  args: z.object({ orgId: z.string(), seniorityIds: z.array(SeniorityIdSchema) }),
+  args: z.object({
+    orgId: z.string(),
+    seniorityIds: z.array(SeniorityIdSchema),
+  }),
   handler: async (ctx, { orgId, seniorityIds }) => {
     const companyId = await getCompanyIdByClerkOrgId(ctx, {
       clerkOrgId: orgId,

--- a/apps/hire/convex/targetTeams.ts
+++ b/apps/hire/convex/targetTeams.ts
@@ -1,0 +1,71 @@
+import { zCustomMutation, zCustomQuery } from "convex-helpers/server/zod";
+import { NoOp } from "convex-helpers/server/customFunctions";
+import {
+  TargetTeamIdSchema,
+  TargetTeamSchema,
+} from "../src/server/zod/targetTeam";
+import z from "zod";
+import { query, mutation } from "./_generated/server";
+import { getCompanyIdByClerkOrgId } from "./model/companies";
+
+const targetTeamQuery = zCustomQuery(query, NoOp);
+const targetTeamMutation = zCustomMutation(mutation, NoOp);
+
+export const getTargetTeams = targetTeamQuery({
+  args: z.object({ orgId: z.string() }),
+  handler: async (ctx, { orgId }) => {
+    const companyId = await getCompanyIdByClerkOrgId(ctx, {
+      clerkOrgId: orgId,
+    });
+    const targetTeams = await ctx.db
+      .query("targetTeams")
+      .withIndex("by_company_order", (q) => q.eq("companyId", companyId))
+      .order("asc")
+      .collect();
+    return z.array(TargetTeamSchema).parse(targetTeams);
+  },
+  returns: z.array(TargetTeamSchema),
+});
+
+export const addTargetTeam = targetTeamMutation({
+  args: z.object({ orgId: z.string(), name: z.string() }),
+  handler: async (ctx, { orgId, name }) => {
+    const companyId = await getCompanyIdByClerkOrgId(ctx, {
+      clerkOrgId: orgId,
+    });
+    const highestOrder = await ctx.db
+      .query("targetTeams")
+      .withIndex("by_company_order", (q) => q.eq("companyId", companyId))
+      .order("desc")
+      .first()
+      .then((team) => (team ? team.order + 1 : 0));
+    await ctx.db.insert("targetTeams", {
+      companyId,
+      name,
+      order: highestOrder,
+    });
+  },
+});
+
+export const reorderTargetTeams = targetTeamMutation({
+  args: z.object({ targetTeamIds: z.array(TargetTeamIdSchema) }),
+  handler: async (ctx, { targetTeamIds }) => {
+    await Promise.all(
+      targetTeamIds.map((id, index) => ctx.db.patch(id, { order: index })),
+    );
+  },
+});
+
+export const deleteTargetTeam = targetTeamMutation({
+  args: z.object({ orgId: z.string(), _id: TargetTeamIdSchema }),
+  handler: async (ctx, { orgId, _id }) => {
+    const companyId = await getCompanyIdByClerkOrgId(ctx, {
+      clerkOrgId: orgId,
+    });
+    const targetTeam = await ctx.db.get(_id);
+    if (!targetTeam) throw new Error("Target Team not found");
+    if (targetTeam.companyId !== companyId)
+      throw new Error("Target Team does not belong to this company");
+    await ctx.db.delete(_id);
+  },
+});

--- a/apps/hire/src/app/board/[slug]/page.tsx
+++ b/apps/hire/src/app/board/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default function BoardPage({
     );
   }
 
-  const { board, stages, candidates } = boardWithData;
+  const { board, stages, candidates, targetTeams } = boardWithData;
 
   // Filter stages based on the board's configuration
   const configuredStages = stages.filter((stage) =>
@@ -87,6 +87,7 @@ export default function BoardPage({
         stages={configuredStages}
         candidates={candidates}
         organizationId={organizationId}
+        targetTeams={targetTeams}
       />
     </div>
   );

--- a/apps/hire/src/app/settings/_components/kanban-stages-tab.tsx
+++ b/apps/hire/src/app/settings/_components/kanban-stages-tab.tsx
@@ -60,7 +60,10 @@ export function KanbanStagesTab({ orgId }: { orgId: string }) {
               };
             });
             setLocalStages(updatedStages);
-            reorderStages({ stageIds: newStages.map((s) => s.id) });
+            reorderStages({
+              orgId,
+              stageIds: newStages.map((s) => s.id),
+            });
           }}
           onTagDeleted={(tagId) => deleteStage({ orgId, _id: tagId })}
         />

--- a/apps/hire/src/app/settings/_components/roles-tab.tsx
+++ b/apps/hire/src/app/settings/_components/roles-tab.tsx
@@ -60,7 +60,7 @@ export function RolesTab({ orgId }: { orgId: string }) {
               };
             });
             setLocalRoles(updatedRoles);
-            reorderRoles({ roleIds: newRoles.map((r) => r.id) });
+            reorderRoles({ orgId, roleIds: newRoles.map((r) => r.id) });
           }}
           onTagDeleted={(tagId) => deleteRole({ orgId, _id: tagId })}
         />

--- a/apps/hire/src/app/settings/_components/seniority-tab.tsx
+++ b/apps/hire/src/app/settings/_components/seniority-tab.tsx
@@ -65,6 +65,7 @@ export function SeniorityTab({ orgId }: { orgId: string }) {
             );
             setLocalSeniorities(updatedSeniorities);
             reorderSeniorities({
+              orgId,
               seniorityIds: newSeniorities.map((s) => s.id),
             });
           }}

--- a/apps/hire/src/app/settings/_components/sources-tab.tsx
+++ b/apps/hire/src/app/settings/_components/sources-tab.tsx
@@ -62,7 +62,10 @@ export function SourcesTab({ orgId }: { orgId: string }) {
               order: i,
             }));
             setLocalSources(updatedSources);
-            reorderSources({ sourceIds: updatedSources.map((s) => s._id) });
+            reorderSources({
+              orgId,
+              sourceIds: updatedSources.map((s) => s._id),
+            });
           }}
           onTagDeleted={(tagId) => deleteSource({ orgId, _id: tagId })}
         />

--- a/apps/hire/src/app/settings/_components/target-team-tab.tsx
+++ b/apps/hire/src/app/settings/_components/target-team-tab.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button, Input } from "@j5/component-library";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { useEffect, useState } from "react";
+import { SortableTagList } from "./sortable-tag-list";
+import type { TargetTeam } from "../../../server/zod/targetTeam";
+
+export function TargetTeamTab({ orgId }: { orgId: string }) {
+  const [targetTeamName, setTargetTeamName] = useState("");
+  const targetTeams = useQuery(api.targetTeams.getTargetTeams, { orgId }) || [];
+  const [localTargetTeams, setLocalTargetTeams] =
+    useState<TargetTeam[]>(targetTeams);
+  const addTargetTeam = useMutation(api.targetTeams.addTargetTeam);
+  const reorderTargetTeams = useMutation(api.targetTeams.reorderTargetTeams);
+  const deleteTargetTeam = useMutation(api.targetTeams.deleteTargetTeam);
+
+  useEffect(() => {
+    setLocalTargetTeams(targetTeams);
+  }, [targetTeams]);
+
+  if (!orgId) return null;
+
+  const handleAddTargetTeam = () => {
+    if (!targetTeamName.trim()) return;
+    addTargetTeam({ name: targetTeamName.trim(), orgId });
+    setTargetTeamName("");
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Target Teams</h2>
+      <p className="text-muted-foreground text-sm">
+        Define the target teams for your organization
+      </p>
+      <div className="flex items-center justify-between gap-4">
+        <Input
+          placeholder="New target team"
+          value={targetTeamName}
+          onChange={(e) => setTargetTeamName(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAddTargetTeam()}
+        />
+        <Button onClick={handleAddTargetTeam} disabled={!targetTeamName.trim()}>
+          Add Team
+        </Button>
+      </div>
+      <div className="rounded-lg border p-4">
+        <SortableTagList
+          initialTags={
+            localTargetTeams?.map(({ _id, name, ...rest }) => ({
+              value: name,
+              id: _id,
+              ...rest,
+            })) || []
+          }
+          onTagsSorted={(newTeams) => {
+            const updatedTeams = newTeams.map(({ id, value, ...rest }, i) => {
+              return {
+                _id: id,
+                name: value,
+                ...rest,
+                order: i,
+              };
+            });
+            setLocalTargetTeams(updatedTeams);
+            reorderTargetTeams({
+              targetTeamIds: newTeams.map((t) => t.id),
+            });
+          }}
+          onTagDeleted={(tagId) => deleteTargetTeam({ orgId, _id: tagId })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/hire/src/app/settings/_components/target-team-tab.tsx
+++ b/apps/hire/src/app/settings/_components/target-team-tab.tsx
@@ -65,8 +65,10 @@ export function TargetTeamTab({ orgId }: { orgId: string }) {
             });
             setLocalTargetTeams(updatedTeams);
             reorderTargetTeams({
+              orgId,
               targetTeamIds: newTeams.map((t) => t.id),
             });
+            // TODO: Add toast notification on success or failure
           }}
           onTagDeleted={(tagId) => deleteTargetTeam({ orgId, _id: tagId })}
         />

--- a/apps/hire/src/app/settings/page.tsx
+++ b/apps/hire/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { RolesTab } from "./_components/roles-tab";
 import { SourcesTab } from "./_components/sources-tab";
 import { KanbanStagesTab } from "./_components/kanban-stages-tab";
 import { BoardsTab } from "./_components/boards-tab";
+import { TargetTeamTab } from "./_components/target-team-tab";
 import { useOrganization } from "@clerk/nextjs";
 
 export const dynamic = "force-dynamic";
@@ -25,8 +26,9 @@ export default function SettingsPage() {
         <SeniorityTab orgId={orgId} />
         <RolesTab orgId={orgId} />
         <SourcesTab orgId={orgId} />
-        <KanbanStagesTab orgId={orgId} />
+        <TargetTeamTab orgId={orgId} />
         <BoardsTab orgId={orgId} />
+        <KanbanStagesTab orgId={orgId} />
       </div>
     </div>
   );

--- a/apps/hire/src/components/candidate/candidate-form.tsx
+++ b/apps/hire/src/components/candidate/candidate-form.tsx
@@ -64,6 +64,8 @@ export function CandidateForm<T extends AcceptableSchemas>({
   const kanbanStages =
     useQuery(api.kanbanStages.getKanbanStages, { orgId: organizationId }) || [];
   const roles = useQuery(api.roles.getRoles, { orgId: organizationId }) || [];
+  const targetTeams =
+    useQuery(api.targetTeams.getTargetTeams, { orgId: organizationId }) || [];
 
   return (
     <Card className="w-full max-w-2xl p-6">
@@ -139,8 +141,21 @@ export function CandidateForm<T extends AcceptableSchemas>({
           <form.AppField name="nextSteps">
             {(field) => <field.FieldInput label="Next Steps" />}
           </form.AppField>
-          <form.AppField name="targetTeam">
-            {(field) => <field.FieldInput label="Target Team" />}
+          <form.AppField name="targetTeamId">
+            {(field) => (
+              <field.FieldSelect label="Target Team">
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a target team" />
+                </SelectTrigger>
+                <SelectContent>
+                  {targetTeams.map((team) => (
+                    <SelectItem key={team._id} value={team._id}>
+                      {team.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </field.FieldSelect>
+            )}
           </form.AppField>
           <form.AppField name="roleId">
             {(field) => (

--- a/apps/hire/src/components/kanban/KanbanBoard.tsx
+++ b/apps/hire/src/components/kanban/KanbanBoard.tsx
@@ -19,17 +19,20 @@ import type {
 } from "~/server/zod/candidate";
 import { KanbanStageId, ZodKanbanStage } from "~/server/zod/kanbanStage";
 import { EditCandidateSheet } from "../candidate/edit-candidate-sheet";
+import type { TargetTeam } from "~/server/zod/targetTeam";
 
 interface KanbanBoardProps {
   stages: ZodKanbanStage[];
   candidates: ZodCandidate[];
   organizationId: string;
+  targetTeams: TargetTeam[];
 }
 
 export function KanbanBoard({
   stages,
   candidates,
   organizationId,
+  targetTeams,
 }: KanbanBoardProps) {
   const updateCandidateStage = useMutation(api.candidates.updateCandidateStage);
   const updateCandidateDetails = useMutation(api.candidates.updateCandidate);
@@ -119,6 +122,7 @@ export function KanbanBoard({
             title={stage.name}
             candidates={candidates.filter((c) => c.kanbanStageId === stage._id)}
             onCardClick={handleCardClick}
+            targetTeams={targetTeams}
           />
         ))}
       </DndContext>

--- a/apps/hire/src/components/kanban/KanbanCard.tsx
+++ b/apps/hire/src/components/kanban/KanbanCard.tsx
@@ -3,13 +3,16 @@
 import React, { memo } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import { ZodCandidate } from "~/server/zod/candidate";
+import type { TargetTeam } from "~/server/zod/targetTeam";
 
 export const KanbanCard = memo(function KanbanCard({
   candidate,
   onClick,
+  targetTeams,
 }: {
   candidate: ZodCandidate;
   onClick: (candidate: ZodCandidate) => void;
+  targetTeams: TargetTeam[];
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: candidate._id });
@@ -20,6 +23,11 @@ export const KanbanCard = memo(function KanbanCard({
     opacity: isDragging ? 0.5 : 1,
     cursor: isDragging ? "grabbing" : "grab",
   };
+
+  const targetTeamName = candidate.targetTeamId
+    ? targetTeams.find((tt) => tt._id === candidate.targetTeamId)?.name
+    : null;
+
   return (
     <div
       ref={setNodeRef}
@@ -32,6 +40,11 @@ export const KanbanCard = memo(function KanbanCard({
       <span className="font-medium text-[var(--color-slate-12)]">
         {candidate.name}
       </span>
+      {targetTeamName && (
+        <span className="mt-1 block text-xs text-[var(--color-slate-11)]">
+          {targetTeamName}
+        </span>
+      )}
     </div>
   );
 });

--- a/apps/hire/src/components/kanban/KanbanColumn.tsx
+++ b/apps/hire/src/components/kanban/KanbanColumn.tsx
@@ -8,12 +8,14 @@ import {
 } from "@dnd-kit/sortable";
 import { KanbanCard } from "./KanbanCard";
 import { ZodCandidate } from "~/server/zod/candidate";
+import type { TargetTeam } from "~/server/zod/targetTeam";
 
 interface KanbanColumnProps {
   id: string;
   title: string;
   candidates: ZodCandidate[];
   onCardClick: (candidate: ZodCandidate) => void;
+  targetTeams: TargetTeam[];
 }
 
 const getColumnStyles = (isOver: boolean) => {
@@ -30,6 +32,7 @@ export function KanbanColumn({
   title,
   candidates,
   onCardClick,
+  targetTeams,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   return (
@@ -47,6 +50,7 @@ export function KanbanColumn({
               key={candidate._id}
               candidate={candidate}
               onClick={() => onCardClick(candidate)}
+              targetTeams={targetTeams}
             />
           ))}
         </div>

--- a/apps/hire/src/server/zod/candidate.ts
+++ b/apps/hire/src/server/zod/candidate.ts
@@ -4,6 +4,7 @@ import { zid } from "convex-helpers/server/zod";
 import { baseConvexFieldsOmit, nonEmptyString } from "./utils";
 import { CompanyIdSchema } from "./company";
 import { baseConvexFields } from "./utils";
+import { TargetTeamIdSchema } from "./targetTeam";
 
 export const CandidateIdSchema = zid("candidates");
 
@@ -21,7 +22,7 @@ export const CandidateSchema = z.object({
   salaryExpectations: z.string().optional(),
   seniorityId: zid("seniorities").optional(),
   sourceId: zid("sources").optional(),
-  targetTeam: z.string().optional(),
+  targetTeamId: TargetTeamIdSchema.optional(),
   updatedAt: z.number(),
 });
 

--- a/apps/hire/src/server/zod/targetTeam.ts
+++ b/apps/hire/src/server/zod/targetTeam.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { zid } from "convex-helpers/server/zod";
+import { baseConvexFields, nonEmptyString } from "./utils";
+import { CompanyIdSchema } from "./company";
+
+export const TargetTeamIdSchema = zid("targetTeams");
+export type TargetTeamId = z.infer<typeof TargetTeamIdSchema>;
+
+export const TargetTeamSchema = z.object({
+  ...baseConvexFields("targetTeams"),
+  companyId: CompanyIdSchema,
+  name: nonEmptyString,
+  order: z.number(),
+});
+export type TargetTeam = z.infer<typeof TargetTeamSchema>;
+
+export const CreateTargetTeamSchema = z.object({
+  name: nonEmptyString,
+});
+export type CreateTargetTeam = z.infer<typeof CreateTargetTeamSchema>;
+
+export const UpdateTargetTeamSchema = TargetTeamSchema.pick({
+  _id: true,
+  name: true,
+});
+export type UpdateTargetTeam = z.infer<typeof UpdateTargetTeamSchema>;

--- a/apps/hire/src/server/zod/views/board-with-data.ts
+++ b/apps/hire/src/server/zod/views/board-with-data.ts
@@ -2,11 +2,13 @@ import { BoardSchema } from "../board";
 import { KanbanStageSchema } from "../kanbanStage";
 import { z } from "zod";
 import { CandidateSchema } from "../candidate";
+import { TargetTeamSchema } from "../targetTeam";
 
 export const BoardWithDataSchema = z.object({
   board: BoardSchema,
   stages: z.array(KanbanStageSchema),
   candidates: z.array(CandidateSchema),
+  targetTeams: z.array(TargetTeamSchema),
 });
 
 export type BoardWithData = z.infer<typeof BoardWithDataSchema>;


### PR DESCRIPTION
- **hire: make target team a dropdown**
- **remove todo**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced "target teams" as a new entity, allowing users to create, reorder, and delete target teams within organization settings.
  - Added a dedicated tab in settings for managing target teams.
  - Candidate forms now allow selecting a target team from a dropdown list.
  - Kanban board and cards now display candidates' associated target teams.

- **Enhancements**
  - Improved data structure for associating candidates with target teams for better organization and clarity.
  - Added organization-level validation when reordering roles, stages, seniorities, and sources to ensure data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->