### PR TITLE
feat: replace temporary textarea with component library Textarea

### DIFF
--- a/apps/hackathon/src/components/shared/comments.stories.tsx
+++ b/apps/hackathon/src/components/shared/comments.stories.tsx
@@ -229,7 +229,7 @@ export const AddCommentFlow: Story = {
       await userEvent.click(addButton);
 
       // Form should be visible
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       expect(textarea).toBeInTheDocument();
       expect(textarea).toBeVisible();
 
@@ -241,7 +241,7 @@ export const AddCommentFlow: Story = {
     });
 
     await step("Type comment and submit", async () => {
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       await userEvent.type(textarea, "This is a test comment!");
 
       // Submit button should now be enabled
@@ -253,7 +253,7 @@ export const AddCommentFlow: Story = {
       // Form should close
       await waitFor(() => {
         expect(
-          canvas.queryByPlaceholderText("Write a comment..."),
+          canvas.queryByTestId("comment-textarea"),
         ).not.toBeInTheDocument();
       });
 
@@ -291,7 +291,7 @@ export const CancelCommentFlow: Story = {
       await userEvent.click(addButton);
 
       // Type some text
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       await userEvent.type(textarea, "This text should be cleared");
 
       // Cancel
@@ -300,7 +300,7 @@ export const CancelCommentFlow: Story = {
 
       // Form should be closed
       expect(
-        canvas.queryByPlaceholderText("Write a comment..."),
+        canvas.queryByTestId("comment-textarea"),
       ).not.toBeInTheDocument();
       expect(canvas.getByTestId("add-comment-button")).toBeInTheDocument();
     });
@@ -311,7 +311,7 @@ export const CancelCommentFlow: Story = {
       await userEvent.click(addButton);
 
       // Text should be empty
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       expect(textarea).toHaveValue("");
     });
   },
@@ -458,7 +458,7 @@ export const ErrorHandling: Story = {
       const addButton = canvas.getByTestId("add-comment-button");
       await userEvent.click(addButton);
 
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       await userEvent.type(textarea, "This will fail");
 
       const submitButton = canvas.getByTestId("submit-comment-button");
@@ -467,7 +467,7 @@ export const ErrorHandling: Story = {
       // Form should remain open after error
       await waitFor(() => {
         expect(
-          canvas.getByPlaceholderText("Write a comment..."),
+          canvas.getByTestId("comment-textarea"),
         ).toBeInTheDocument();
       });
     });
@@ -508,7 +508,7 @@ export const LoadingState: Story = {
       const addButton = canvas.getByTestId("add-comment-button");
       await userEvent.click(addButton);
 
-      const textarea = canvas.getByPlaceholderText("Write a comment...");
+      const textarea = canvas.getByTestId("comment-textarea");
       await userEvent.type(textarea, "Loading test");
 
       const submitButton = canvas.getByTestId("submit-comment-button");
@@ -526,7 +526,7 @@ export const LoadingState: Story = {
       await waitFor(
         () => {
           expect(
-            canvas.queryByPlaceholderText("Write a comment..."),
+            canvas.queryByTestId("comment-textarea"),
           ).not.toBeInTheDocument();
         },
         { timeout: 2000 },

--- a/apps/hackathon/src/components/shared/comments.tsx
+++ b/apps/hackathon/src/components/shared/comments.tsx
@@ -8,6 +8,7 @@ import {
   AvatarFallback,
   AvatarImage,
   Button,
+  Textarea,
 } from "@j5/component-library";
 import { ThumbsUp } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
@@ -209,13 +210,12 @@ export function Comments<TProjectId extends ProjectId>({
       <div className="border-slate-6 mt-4 border-t pt-2">
         {showCommentForm ? (
           <div className="space-y-2">
-            {/* TODO: replace with component library textarea after hackathon storybook is built */}
-            <textarea
-              className="border-slate-7 bg-slate-3 text-slate-12 focus:ring-grass-9 focus:border-grass-9 w-full rounded-md border p-2 text-sm"
+            <Textarea
               rows={3}
               placeholder="Write a comment..."
               value={newCommentText}
               onChange={(e) => setNewCommentText(e.target.value)}
+              dataTestId={`${config.testIdTarget}-textarea`}
             />
             <div className="flex justify-end gap-2">
               <Button


### PR DESCRIPTION
## Summary

Replaces the temporary textarea implementation in hackathon comments with the proper component library Textarea component.

## Changes Made

- ✅ Added `Textarea` import from `@j5/component-library`
- ✅ Replaced temporary `<textarea>` with `<Textarea>` component  
- ✅ Added proper `dataTestId` prop for testing consistency
- ✅ Updated all Storybook stories to use test IDs instead of placeholder text
- ✅ Removed TODO comment

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ All existing functionality preserved
- ✅ Storybook stories updated and verified

## Linear Ticket

Fixes [JAC-76](https://linear.app/jacksondr5/issue/JAC-76/replace-with-component-library-textarea-in-hackathon-comments)