### PR TITLE
have prettier ignore mcp.json and switch Nx MCP to stdio

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,16 +1,14 @@
 {
   "mcpServers": {
     "nx-mcp": {
-      "command": "npx",
+      "command": "pnpm dlx",
       "args": [
-        "-y",
         "nx-mcp@latest"
       ]
     },
     "convex": {
       "command": "pnpm dlx",
       "args": [
-        "-y",
         "convex@latest",
         "mcp",
         "start"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,15 +1,26 @@
 {
   "mcpServers": {
     "nx-mcp": {
-      "url": "http://localhost:9119/sse"
+      "command": "npx",
+      "args": [
+        "-y",
+        "nx-mcp@latest"
+      ]
     },
     "convex": {
       "command": "pnpm dlx",
-      "args": ["-y", "convex@latest", "mcp", "start"]
+      "args": [
+        "-y",
+        "convex@latest",
+        "mcp",
+        "start"
+      ]
     },
     "browsermcp": {
       "command": "pnpm dlx",
-      "args": ["@browsermcp/mcp@latest"]
+      "args": [
+        "@browsermcp/mcp@latest"
+      ]
     }
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 pnpm-lock.yaml
 storybook-static
 node_modules
+.cursor/mcp.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated MCP server setup to launch via a CLI command for improved reliability and compatibility.
  * Reformatted MCP command arguments for consistency; behavior unchanged.
  * Excluded MCP configuration from automatic code formatting to prevent unintended edits.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->